### PR TITLE
Fix ambigous match on worlds sdk

### DIFF
--- a/WorldSdkPatcher.cs
+++ b/WorldSdkPatcher.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 using VRC.SDK3.Editor.Builder;
 
 [HarmonyPatch(typeof(VRCWorldAssetExporter))]
-[HarmonyPatch("ExportCurrentSceneResource")]
+[HarmonyPatch("ExportCurrentSceneResource", new Type[] { typeof(bool), typeof(Action<string>), typeof(Action<object>) })]
 class ExportCurrentSceneResourcePatch
 {
     static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)


### PR DESCRIPTION
Was getting an ambiguous match on world 3.5.0, still couldn't upload, but this at least fixes that ambiguous match.